### PR TITLE
timeout only used by pyserial's read/read_until()

### DIFF
--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -5,7 +5,7 @@ import time
 from gps_serial import GPSserial
 
 # you may want to adjust the port address that is passed to the constructor accordingly.
-GPS = GPSserial('/dev/ttyS0')
+GPS = GPSserial('COM4')
 while True:
     try:
         GPS.get_data() # pass `1` or `true` to print raw data from module

--- a/gps_serial.py
+++ b/gps_serial.py
@@ -48,15 +48,14 @@ def _convert2deg(nmea):
 class GPSserial:
     """
     :param int address: The serial port address that the GPS module is connected to. For example, on the raspberry pi's GPIO pins, this is ``/dev/ttyS0``; on windows, this is something like ``com#`` where # is designated by windows.
-    :param int timeout: Specific number of seconds till the threading :class:`~serial.Serial`'s ``readline()`` operation expires. Defaults to 1 second.
+    :param int timeout: Specific number of seconds till the threading :class:`~serial.Serial`'s `~serial.Serial.read_until()` operation expires. Defaults to 1 second.
+    :param int baud: The specific baudrate to be used for the serial connection. If left
+
     """
-    def __init__(self, address, timeout=1.0, baud=-1):
-        if baud < 0:
-            self._ser = Serial(address, timeout=timeout)
-        else:
-            self._ser = Serial(address, baud, timeout=timeout)
+    def __init__(self, address, timeout=1.0, baud=9600):
+        self._ser = Serial(address=address, baud=baud, timeout=timeout)
         # print('Successfully opened port {} @ {} to Arduino device'.format(address, baud))
-        self._line = self._ser.readline()  # discard any garbage artifacts
+        self._line = self._ser.read_until()  # discard any garbage artifacts
         self._ser.close()
         self._gps_thread = None
         # print('Successfully opened port', address, 'to GPS module')


### PR DESCRIPTION

- now uses pySerial library's builtin context manager to avoid port conflicts (AKA accessing a port that is already open). 
- added some checking to avoid creating a new thread while old/previous thread is still "alive"
- timeout parameter only had an affect when using `Serial.read()` or `Serial.read_until()`, not when using the `Serial.readline()` (which is really a wrapper of python's `io.IOBase.readline()` that doesn't use timeouts). We are now using `Serial.read_until()` which terminates upon specified timeout or when the `\n` (LF) character is read from the input stream.

there may still be a bug in the `threaded_read()` concerning the `found` boolean. Specifically when thread is initiated between input stream "pulses" from GPS device (input stream bytes (`Serial.in_waiting`) = 0 and found = init value of `False`) meaning the `threaded_read()` will hang extra long.